### PR TITLE
[transferengine] Allow D-Bus activation only through systemd. JB#52572

### DIFF
--- a/dbus/org.nemo.transferengine.service
+++ b/dbus/org.nemo.transferengine.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Interface=/org/nemo/transferengine
 Name=org.nemo.transferengine
-Exec=/usr/bin/invoker --type=qt5 --global-syms /usr/bin/nemo-transfer-engine
+Exec=/bin/false
 SystemdService=transferengine.service


### PR DESCRIPTION
Starting D-Bus services should happen only via systemd. Using a dummy
Exec line in D-Bus configuration ensures that systemd can't be bypassed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>