### PR TITLE
[transferengine] Don't mess up with external createDownload path. JB#61156

### DIFF
--- a/lib/transferengineclient.cpp
+++ b/lib/transferengineclient.cpp
@@ -136,9 +136,9 @@ public:
 
     // Create the sync event
     int transferId = client->createSyncEvent("Syncing data from my service",
-                                           QUrl("image://theme/icon-launcher-my-app"),
-                                           QUrl("image://theme/icon-s-service-icon"),
-                                           callback);
+                                             QUrl("image://theme/icon-launcher-my-app"),
+                                             QUrl("image://theme/icon-s-service-icon"),
+                                             callback);
 
     // Start the actual transfer i.e. sync
     client->startTransfer(transferId)
@@ -159,10 +159,10 @@ public:
     TransferEngineClient status;
     QString reason;
     if (ok) {
-     status = TransferEngineClient::TransferFinished;
+        status = TransferEngineClient::TransferFinished;
     } else {
-     status = TransferEngineClient::TransferInterrupted;
-     reason = "Something went wrong";
+        status = TransferEngineClient::TransferInterrupted;
+        reason = "Something went wrong";
     }
 
     client->finishTransfer(transferId, status, reason);
@@ -205,7 +205,7 @@ TransferEngineClient::~TransferEngineClient()
     Creates a download event to the TransferEngine. This method requires the following parameters
     \a displayName, a human readable name for the entry. \a applicationIcon is the \c QUrl to the icon
     of the application, who's calling this method. Usually it can be in format "image://theme/icon-s-something".
-    \a serviceIcon is a service specific icon such as DropBox. \a url is the url to the media to be downloaded.
+    \a serviceIcon is a service specific icon such as DropBox. \a url is the url to the local file to be downloaded.
     \a mimeType is the mimeType of the media and \a expectedFileSize is the file size of the file to be downloaded.
 
     Client can define callback functions for canceling and restarting download. For that client can provide
@@ -225,18 +225,18 @@ TransferEngineClient::~TransferEngineClient()
     \sa createSyncEvent(), startTransfer(), updateTransferProgress(), finishTransfer()
  */
 int TransferEngineClient::createDownloadEvent(const QString &displayName,
-                                                      const QUrl &applicationIcon,
-                                                      const QUrl &serviceIcon,
-                                                      const QUrl &url,
-                                                      const QString &mimeType,
-                                                      qlonglong expectedFileSize,
-                                                      const CallbackInterface &callback)
+                                              const QUrl &applicationIcon,
+                                              const QUrl &serviceIcon,
+                                              const QUrl &url,
+                                              const QString &mimeType,
+                                              qlonglong expectedFileSize,
+                                              const CallbackInterface &callback)
 {
     Q_D(const TransferEngineClient);
     QDBusPendingReply<int> reply = d->m_client->createDownload(displayName,
                                                                applicationIcon.toString(),
                                                                serviceIcon.toString(),
-                                                               url.toString(),
+                                                               url.toLocalFile(),
                                                                mimeType,
                                                                expectedFileSize,
                                                                callback.d_func()->callback,
@@ -269,9 +269,9 @@ int TransferEngineClient::createDownloadEvent(const QString &displayName,
     \sa startTransfer(), updateTransferProgress(), finishTransfer()
  */
 int TransferEngineClient::createSyncEvent(const QString &displayName,
-                                                  const QUrl &applicationIcon,
-                                                  const QUrl &serviceIcon,
-                                                  const CallbackInterface &callback)
+                                          const QUrl &applicationIcon,
+                                          const QUrl &serviceIcon,
+                                          const CallbackInterface &callback)
 {
     Q_D(const TransferEngineClient);
     QDBusPendingReply<int> reply = d->m_client->createSync(displayName,

--- a/src/transferengine.cpp
+++ b/src/transferengine.cpp
@@ -840,7 +840,7 @@ int TransferEngine::uploadMediaItemContent(const QVariantMap &content,
         \li \a displayName  The name for Download which may be used by the UI displaying the download
         \li \a applicationIcon The application icon of the application created the download
         \li \a serviceIcon The service icon, which provides the file to be downloaded
-        \li \a filePath The filePath e.g. url to the file to be downloaded
+        \li \a filePath The filePath to the file to be downloaded
         \li \a mimeType the MimeType of the file to be downloaded
         \li \a expectedFileSize The file size of the file to be downloaded
         \li \a callback QStringList containing DBus callback information such as: service, path and interface
@@ -865,7 +865,7 @@ int TransferEngine::createDownload(const QString &displayName,
                                    const QString &restartMethod)
 {
     Q_D(TransferEngine);
-    QUrl url(filePath);
+    QUrl url = QUrl::fromLocalFile(filePath);
     QFileInfo fileInfo(filePath);
 
     MediaItem *mediaItem = new MediaItem();


### PR DESCRIPTION
The filepath vs url confusion still continuing. The d-bus defines it as path so use QUrl::fromLocalFile to convert it to url.

