### PR TITLE
WIP: Allow to create private transfers

### DIFF
--- a/dbus/org.nemo.transferengine.xml
+++ b/dbus/org.nemo.transferengine.xml
@@ -48,6 +48,21 @@
             <arg direction="out" type="i" name="transferId"/>
         </method>
 
+        # create transient Download entry
+        <method name="createTransientDownload">
+            <arg direction="in" type="s" name="displayName"/>
+            <arg direction="in" type="s" name="applicationIcon"/>
+            <arg direction="in" type="s" name="serviceIcon"/>
+            <arg direction="in" type="s" name="filePath"/>
+            <arg direction="in" type="s" name="mimeType"/>
+            <arg direction="in" type="x" name="expectedFileSize"/>
+            <arg direction="in" type="b" name="transient"/>
+            <arg direction="in" type="as" name="callback"/>
+            <arg direction="in" type="s" name="cancelMethod"/>
+            <arg direction="in" type="s" name="restartMethod"/>
+            <arg direction="out" type="i" name="transferId"/>
+        </method>
+
         # API for updating either download or sync
         <method name="updateTransferProgress">
             <arg direction="in" type="i" name="transferId"/>

--- a/declarative/declarativetransfermodel.cpp
+++ b/declarative/declarativetransfermodel.cpp
@@ -356,7 +356,7 @@ bool TransferModel::executeQuery(QVector<TransferDBRecord> *rows, int *activeTra
     QSqlQuery query(db);
     query.setForwardOnly(true);
 
-    if (!query.exec(QString(QStringLiteral("SELECT * FROM transfers ORDER BY transfer_id DESC")))) {
+    if (!query.exec(QString(QStringLiteral("SELECT * FROM transfers WHERE transient=0 ORDER BY transfer_id DESC")))) {
         qWarning() << Q_FUNC_INFO;
         qWarning() << "Failed to create tmp table";
         qWarning() << query.lastQuery();

--- a/lib/mediaitem.cpp
+++ b/lib/mediaitem.cpp
@@ -73,8 +73,9 @@ public:
     \value Description      Description for the media item to be transfered
     \value ServiceIcon      Service icon URL e.g. email service
     \value ApplicationIcon  Application icon url
-    \value AccountId,       Account Id
+    \value AccountId        Account Id
     \value UserData         User specific data that is passed from the UI
+    \value Transient        Flag to indicate if it should be shown in the transfer list or not.
     \value Callback         Callback service, path, interface packed to QStringList
     \value CancelCBMethod   Cancel callback method name
     \value RestartCBMethod  Restart callback method name

--- a/lib/mediaitem.h
+++ b/lib/mediaitem.h
@@ -53,6 +53,7 @@ public:
         ThumbnailIcon,
         AccountId,
         UserData,
+        Transient,
 
         // Callback methods comes from the API, not from the plugins
         Callback,

--- a/lib/transferengineclient.cpp
+++ b/lib/transferengineclient.cpp
@@ -202,6 +202,20 @@ TransferEngineClient::~TransferEngineClient()
 }
 
 /*!
+    Overloaded method of createDownloadEvent() for compatibility.
+ */
+int TransferEngineClient::createDownloadEvent(const QString &displayName,
+                                              const QUrl &applicationIcon,
+                                              const QUrl &serviceIcon,
+                                              const QUrl &url,
+                                              const QString &mimeType,
+                                              qlonglong expectedFileSize,
+                                              const CallbackInterface &callback)
+{
+    return createDownloadEvent(displayName, applicationIcon, serviceIcon, url, mimeType, expectedFileSize, false, callback);
+}
+
+/*!
     Creates a download event to the TransferEngine. This method requires the following parameters
     \a displayName, a human readable name for the entry. \a applicationIcon is the \c QUrl to the icon
     of the application, who's calling this method. Usually it can be in format "image://theme/icon-s-something".
@@ -230,22 +244,24 @@ int TransferEngineClient::createDownloadEvent(const QString &displayName,
                                               const QUrl &url,
                                               const QString &mimeType,
                                               qlonglong expectedFileSize,
+                                              bool transient,
                                               const CallbackInterface &callback)
 {
     Q_D(const TransferEngineClient);
-    QDBusPendingReply<int> reply = d->m_client->createDownload(displayName,
-                                                               applicationIcon.toString(),
-                                                               serviceIcon.toString(),
-                                                               url.toLocalFile(),
-                                                               mimeType,
-                                                               expectedFileSize,
-                                                               callback.d_func()->callback,
-                                                               callback.d_func()->m_cancelMethod,
-                                                               callback.d_func()->m_restartMethod);
+    QDBusPendingReply<int> reply = d->m_client->createTransientDownload(displayName,
+                                                                        applicationIcon.toString(),
+                                                                        serviceIcon.toString(),
+                                                                        url.toLocalFile(),
+                                                                        mimeType,
+                                                                        expectedFileSize,
+                                                                        transient,
+                                                                        callback.d_func()->callback,
+                                                                        callback.d_func()->m_cancelMethod,
+                                                                        callback.d_func()->m_restartMethod);
     reply.waitForFinished();
 
     if (reply.isError()) {
-        qWarning() << "TransferEngineClient::createDownloadEvent: failed to get transfer ID!";
+        qWarning() << "TransferEngineClient::createTransientDownloadEvent: failed to get transfer ID!";
         return false;
     }
 

--- a/lib/transferengineclient.h
+++ b/lib/transferengineclient.h
@@ -66,6 +66,15 @@ public:
                             qlonglong expectedFileSize,
                             const CallbackInterface &callback = CallbackInterface());
 
+    int createDownloadEvent(const QString &displayName,
+                            const QUrl &applicationIcon,
+                            const QUrl &serviceIcon,
+                            const QUrl &url,
+                            const QString &mimeType,
+                            qlonglong expectedFileSize,
+                            bool transient,
+                            const CallbackInterface &callback = CallbackInterface());
+
 
     int createSyncEvent(const QString &displayName,
                         const QUrl &applicationIcon,

--- a/src/transferengine.h
+++ b/src/transferengine.h
@@ -63,6 +63,17 @@ public Q_SLOTS:
                        const QString &cancelMethod,
                        const QString &restartMethod);
 
+    int createTransientDownload(const QString &displayName,
+                                const QString &applicationIcon,
+                                const QString &serviceIcon,
+                                const QString &filePath,
+                                const QString &mimeType,
+                                qlonglong expectedFileSize,
+                                bool transient,
+                                const QStringList &callback,
+                                const QString &cancelMethod,
+                                const QString &restartMethod);
+
     int createSync(const QString &displayName,
                    const QString &applicationIcon,
                    const QString &serviceIcon,


### PR DESCRIPTION
I don't know if this PR is ready, my goal is to allow to hide transfers from the UI when the client applications sets this new `private` field to `true`.

To make things easier, transfers are still kept in the database, but don't appear in the Transfers list. This should be enough from a privacy point of view IMHO. However, we can also think of a way to clear private Transfers from the DB (maybe by adding a new method?).