### PR TITLE
Share plugin api v2. JB#62100

### DIFF
--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -19,7 +19,10 @@ PUBLIC_HEADERS += \
     mediaitem.h \
     sharingmethodinfo.h \
     sharingplugininfo.h \
+    sharingplugininfov2.h \
+    sharingcontenthints.h \
     sharingplugininterface.h \
+    sharingplugininterfacev2.h \
     sharingpluginloader.h \
     transferengineclient.h \
     imageoperation.h
@@ -32,7 +35,7 @@ SOURCES += \
     mediatransferinterface.cpp \
     mediaitem.cpp \
     sharingmethodinfo.cpp \
-    sharingplugininfo.cpp \
+    sharingcontenthints.cpp \
     sharingpluginloader.cpp \
     transferengineclient.cpp \
     imageoperation.cpp

--- a/lib/sharingcontenthints.cpp
+++ b/lib/sharingcontenthints.cpp
@@ -1,0 +1,52 @@
+#include "sharingcontenthints.h"
+
+class SharingContentHintsPrivate
+{
+public:
+    QString m_mimetype;
+    bool m_multipleFiles = false;
+};
+
+SharingContentHints::SharingContentHints()
+    : d_ptr(new SharingContentHintsPrivate)
+{
+}
+
+SharingContentHints::SharingContentHints(const SharingContentHints &other)
+    : d_ptr(new SharingContentHintsPrivate)
+{
+    *d_ptr = *other.d_ptr;
+}
+
+SharingContentHints &SharingContentHints::operator=(const SharingContentHints &other)
+{
+    if (this != &other) {
+        *d_ptr = *other.d_ptr;
+    }
+    return *this;
+}
+
+SharingContentHints::~SharingContentHints()
+{
+    delete d_ptr;
+}
+
+void SharingContentHints::setMimeType(const QString &mimetype)
+{
+    d_ptr->m_mimetype = mimetype;
+}
+
+QString SharingContentHints::mimeType() const
+{
+    return d_ptr->m_mimetype;
+}
+
+void SharingContentHints::setMultipleFiles(bool multipleFiles)
+{
+    d_ptr->m_multipleFiles = multipleFiles;
+}
+
+bool SharingContentHints::multipleFiles() const
+{
+    return d_ptr->m_multipleFiles;
+}

--- a/lib/sharingcontenthints.h
+++ b/lib/sharingcontenthints.h
@@ -1,0 +1,28 @@
+#ifndef SHARINGCONTENTHINTS_H
+#define SHARINGCONTENTHINTS_H
+
+#include <QString>
+
+class SharingContentHintsPrivate;
+
+// hints and requirements about the shared content.
+class SharingContentHints {
+public:
+    SharingContentHints();
+    ~SharingContentHints();
+    SharingContentHints(const SharingContentHints &other);
+    SharingContentHints &operator=(const SharingContentHints &other);
+
+    // Main mime type, can be generalized as image/* in case there are multiple files without any being
+    // especially important. Empty or "*" matches everything.
+    void setMimeType(const QString &mimetype);
+    QString mimeType() const;
+
+    void setMultipleFiles(bool multiple);
+    bool multipleFiles() const;
+
+private:
+    SharingContentHintsPrivate *d_ptr;
+};
+
+#endif

--- a/lib/sharingplugininfov2.h
+++ b/lib/sharingplugininfov2.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
  * Copyright (c) 2021 Open Mobile Platform LLC.
  *
  * All rights reserved.
@@ -22,35 +23,26 @@
  * Lesser General Public License for more details.
  */
 
-#ifndef TRANSFERPLUGINLOADER_H
-#define TRANSFERPLUGINLOADER_H
+#ifndef SHARINGPLUGININFOV2_H
+#define SHARINGPLUGININFOV2_H
 
 #include <QObject>
-
 #include "sharingmethodinfo.h"
 #include "sharingcontenthints.h"
 
-class SharingPluginLoaderPrivate;
-class SharingPluginLoader : public QObject
+class SharingPluginInfoV2: public QObject
 {
     Q_OBJECT
-
 public:
-    explicit SharingPluginLoader(QObject *parent = nullptr);
-    ~SharingPluginLoader();
+    virtual QList<SharingMethodInfo> info() const = 0;
+    // start query for sharing methods. contentHints contain information on content
+    // about to be shared and can be used to limit what sharing methods are returned.
+    virtual void query(const SharingContentHints &contentHints) = 0;
+    virtual void cancelQuery() = 0;
 
-    const QList<SharingMethodInfo> &sharingMethods() const;
-
-    void querySharingMethods(const SharingContentHints &hints);
-    bool isSharingMethodsInfoReady() const;
-
-signals:
-    void pluginsChanged();
-    void sharingMethodsInfoReady();
-
-private:
-    SharingPluginLoaderPrivate *d_ptr = nullptr;
-    Q_DECLARE_PRIVATE(SharingPluginLoader)
+Q_SIGNALS:
+    void infoReady();
+    void infoError(const QString &msg);
 };
 
-#endif // TRANSFERPLUGINLOADER_H
+#endif // SHARINGPLUGININFOV2_H

--- a/lib/sharingplugininterfacev2.h
+++ b/lib/sharingplugininterfacev2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021 Open Mobile Platform LLC.
+ * Copyright (c) 2021 Open Mobile Platform LLC.
  *
  * All rights reserved.
  *
@@ -22,4 +22,19 @@
  * Lesser General Public License for more details.
  */
 
-#include "sharingplugininfo.h"
+#ifndef SHARINGPLUGININTERFACEV2_H
+#define SHARINGPLUGININTERFACEV2_H
+
+#include <QtPlugin>
+#include "sharingplugininfov2.h"
+
+class SharingPluginInterfaceV2
+{
+public:
+    virtual SharingPluginInfoV2 *infoObject() = 0;
+
+    virtual QString pluginId() const = 0;
+};
+
+Q_DECLARE_INTERFACE(SharingPluginInterfaceV2, "org.sailfishos.SharingPluginInterfaceV2/1.0")
+#endif // SHARINGPLUGININTERFACEV2_H

--- a/lib/sharingpluginloader_p.h
+++ b/lib/sharingpluginloader_p.h
@@ -31,6 +31,11 @@
 #include <QTimer>
 
 #include "sharingmethodinfo.h"
+#include "sharingcontenthints.h"
+#include "sharingplugininfo.h"
+#include "sharingplugininfov2.h"
+#include "sharingplugininterface.h"
+#include "sharingplugininterfacev2.h"
 
 class SharingPluginInfo;
 class SharingPluginLoader;
@@ -43,16 +48,18 @@ public:
     ~SharingPluginLoaderPrivate();
 
 public slots:
-    void load();
+    void query();
 
 signals:
     void pluginsChanged();
-    void pluginsLoaded();
+    void sharingMethodsInfoReady();
 
 private slots:
     void pluginDirChanged();
     void pluginInfoReady();
     void pluginInfoError(const QString &msg);
+    void pluginInfo2Ready();
+    void pluginInfo2Error(const QString &msg);
 
 private:
     static QStringList pluginList();
@@ -61,12 +68,14 @@ private:
     Q_DECLARE_PUBLIC(SharingPluginLoader)
 
     bool m_loading = false;
+    SharingContentHints m_hints;
     Accounts::Manager m_accountManager;
     QTimer m_fileWatcherTimer;
     QFileSystemWatcher m_fileWatcher;
 
     QList<SharingPluginInfo *> m_infoObjects;
-    QList<SharingMethodInfo> m_plugins;
+    QList<SharingPluginInfoV2 *> m_infoObjects2;
+    QList<SharingMethodInfo> m_sharingMethods;
 };
 
 #endif // TRANSFERPLUGINLOADER_P_H

--- a/rpm/nemo-transferengine-qt5.spec
+++ b/rpm/nemo-transferengine-qt5.spec
@@ -13,7 +13,6 @@ BuildRequires: pkgconfig(Qt5Test)
 BuildRequires: pkgconfig(Qt5Qml)
 BuildRequires: pkgconfig(Qt5Quick)
 BuildRequires: pkgconfig(accounts-qt5)
-BuildRequires: desktop-file-utils
 BuildRequires: pkgconfig(quillmetadata-qt5)
 BuildRequires: pkgconfig(nemonotifications-qt5) >= 1.0.4
 BuildRequires: qt5-qttools-qdoc
@@ -29,27 +28,11 @@ Requires(post): systemd
 %description
 %{summary}
 
-%files
-%defattr(-,root,root,-)
-%license license.lgpl
-%{_userunitdir}/transferengine.service
-%{_libdir}/nemo-transferengine
-%{_datadir}/nemo-transferengine
-%{_bindir}/nemo-transfer-engine
-%{_datadir}/dbus-1/services/org.nemo.transferengine.service
-%{_datadir}/translations/*.qm
-%{_datadir}/mapplauncherd/privileges.d/*
-
 %package -n libnemotransferengine-qt5
 Summary: Transfer engine library.
 
 %description -n libnemotransferengine-qt5
 %{summary}
-
-%files -n libnemotransferengine-qt5
-%defattr(-,root,root,-)
-%{_libdir}/*.so.*
-%{_libdir}/qt5/qml/org/nemomobile/transferengine
 
 %package -n libnemotransferengine-qt5-devel
 Summary: Development headers for transfer engine library.
@@ -58,22 +41,11 @@ Requires: libnemotransferengine-qt5 = %{version}
 %description -n libnemotransferengine-qt5-devel
 %{summary}
 
-%files -n libnemotransferengine-qt5-devel
-%defattr(-,root,root,-)
-%{_libdir}/*.so
-%{_includedir}/TransferEngine-qt5
-%{_datadir}/qt5/mkspecs/features/nemotransferengine-plugin-qt5.prf
-%{_libdir}/pkgconfig/nemotransferengine-qt5.pc
-
 %package ts-devel
 Summary:   Translation source for Sailfish Transfer Engine
 
 %description ts-devel
 Translation source for Sailfish Transfer Engine
-
-%files ts-devel
-%defattr(-,root,root,-)
-%{_datadir}/translations/source/*.ts
 
 %package tests
 Summary:   Unit tests for Sailfish Transfer Engine
@@ -81,22 +53,12 @@ Summary:   Unit tests for Sailfish Transfer Engine
 %description tests
 Unit tests for Sailfish Transfer Engine
 
-%files tests
-%defattr(-,root,root,-)
-/opt/tests/nemo-transfer-engine-qt5
-
 %package doc
 Summary:   Documentation for Sailfish Transfer Engine
 License:   BSD
 
 %description doc
 Documentation for Sailfish Transfer Engine
-
-%files doc
-%defattr(-,root,root,-)
-%{_datadir}/doc/%{name}
-
-
 
 %prep
 %setup -q -n %{name}-%{version}
@@ -107,7 +69,6 @@ Documentation for Sailfish Transfer Engine
 %make_build docs
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_datadir}/nemo-transferengine/plugins/sharing
 mkdir -p %{buildroot}/%{_libdir}/nemo-transferengine/plugins/sharing
 mkdir -p %{buildroot}/%{_libdir}/nemo-transferengine/plugins/transfer
@@ -119,9 +80,6 @@ cp -R doc/html/* %{buildroot}/%{_docdir}/%{name}/
 mkdir -p %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d
 
-%post -n libnemotransferengine-qt5
-/sbin/ldconfig
-
 %post
 if [ "$1" -eq 2 ]
 then
@@ -129,6 +87,35 @@ then
     systemctl-user stop transferengine.service || :
 fi
 
-%postun -n libnemotransferengine-qt5
-/sbin/ldconfig
+%post -n libnemotransferengine-qt5 -p /sbin/ldconfig
 
+%postun -n libnemotransferengine-qt5 -p /sbin/ldconfig
+
+%files
+%license license.lgpl
+%{_userunitdir}/transferengine.service
+%{_libdir}/nemo-transferengine
+%{_datadir}/nemo-transferengine
+%{_bindir}/nemo-transfer-engine
+%{_datadir}/dbus-1/services/org.nemo.transferengine.service
+%{_datadir}/translations/*.qm
+%{_datadir}/mapplauncherd/privileges.d/*
+
+%files -n libnemotransferengine-qt5
+%{_libdir}/*.so.*
+%{_libdir}/qt5/qml/org/nemomobile/transferengine
+
+%files -n libnemotransferengine-qt5-devel
+%{_libdir}/*.so
+%{_includedir}/TransferEngine-qt5
+%{_datadir}/qt5/mkspecs/features/nemotransferengine-plugin-qt5.prf
+%{_libdir}/pkgconfig/nemotransferengine-qt5.pc
+
+%files ts-devel
+%{_datadir}/translations/source/*.ts
+
+%files tests
+/opt/tests/nemo-transfer-engine-qt5
+
+%files doc
+%{_datadir}/doc/%{name}

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -39,7 +39,6 @@ public:
     ~DbManager();
 
     int createMetadataEntry(int key, const QString &title, const QString &description);
-
     QStringList callback(int key) const;
 
     int createCallbackEntry(int key,
@@ -50,38 +49,22 @@ public:
                             const QString &restartMethod);
 
     int createTransferEntry(const MediaItem *mediaItem);
-
     bool updateTransferStatus(int key, TransferEngineData::TransferStatus status);
-
     bool updateProgress(int key, qreal progress);
-
     bool removeTransfer(int key);
-
     bool clearFailedTransfers(int excludeKey, TransferEngineData::TransferType type);
-
     bool clearTransfer(int key);
-
     bool clearTransfers();
-
     int transferCount() const;
-
     int activeTransferCount() const;
-
     QList<TransferDBRecord> transfers() const;
-
     QList<TransferDBRecord> activeTransfers() const;
-
     TransferEngineData::TransferType transferType(int key) const;
-
     TransferEngineData::TransferStatus transferStatus(int key) const;
-
     qreal transferProgress(int key) const;
-
     int notificationId(int key);
     bool setNotificationId(int key, int notificationId);
-
     bool callbackMethods(int key, QString &cancelMethod, QString &restartMethod) const;
-
     MediaItem * mediaItem(int key) const;
 
 private:


### PR DESCRIPTION
Main commit message:

The existing sharing plugin mechanism wants to request all the methods
a plugin has support for. However on some cases it's better to ask
what methods there are for specific mime types, possibly with the
information whether it's for a single item or multiple ones.

Here is introduced a new version of the plugin api while still
keeping support for the old.

The SharingPluginLoader had some API changes. It doesn't anymore
request automatically the sharing methodsbut requires the application
using it to trigger a query with some hints on what's being shared.
Also some naming was adjusted as more precise. E.g. plugins() didn't
return a list of plugins but rather sharing methods. A plugin being
able to provide multiple methods.